### PR TITLE
Cache setup & saving

### DIFF
--- a/.env
+++ b/.env
@@ -26,7 +26,9 @@ NGINX_SYMFONY_SERVER_NAME=avast.configuration-manager
 ###< docker/nginx ###
 
 ###> docker/redis ###
+REDIS_HOST=redis
 REDIS_PORT=6379
+REDIS_URL=redis://${REDIS_HOST}:${REDIS_PORT}
 ###< docker/redis ###
 
 ###> symfony/framework-bundle ###

--- a/composer.json
+++ b/composer.json
@@ -6,16 +6,18 @@
     "require": {
         "php": ">=7.2.5",
         "ext-ctype": "*",
+        "ext-dom": "*",
+        "ext-fileinfo": "*",
         "ext-iconv": "*",
+        "ext-libxml": "*",
+        "predis/predis": "^1.1",
+        "symfony/cache": "5.3.*",
         "symfony/console": "5.3.*",
         "symfony/dotenv": "5.3.*",
         "symfony/flex": "^1.3.1",
         "symfony/framework-bundle": "5.3.*",
         "symfony/runtime": "5.3.*",
-        "symfony/yaml": "5.3.*",
-        "ext-fileinfo": "*",
-        "ext-dom": "*",
-        "ext-libxml": "*"
+        "symfony/yaml": "5.3.*"
     },
     "config": {
         "optimize-autoloader": true,

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,74 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d73636ec08f3e3529989144c144b776b",
+    "content-hash": "1eee71a16643092fd4a27d1bd05716e4",
     "packages": [
+        {
+            "name": "predis/predis",
+            "version": "v1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/predis/predis.git",
+                "reference": "b240daa106d4e02f0c5b7079b41e31ddf66fddf8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/predis/predis/zipball/b240daa106d4e02f0c5b7079b41e31ddf66fddf8",
+                "reference": "b240daa106d4e02f0c5b7079b41e31ddf66fddf8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "~4.8"
+            },
+            "suggest": {
+                "ext-curl": "Allows access to Webdis when paired with phpiredis",
+                "ext-phpiredis": "Allows faster serialization and deserialization of the Redis protocol"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Predis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Daniele Alessandri",
+                    "email": "suppakilla@gmail.com",
+                    "homepage": "http://clorophilla.net",
+                    "role": "Creator & Maintainer"
+                },
+                {
+                    "name": "Till Krüss",
+                    "homepage": "https://till.im",
+                    "role": "Maintainer"
+                }
+            ],
+            "description": "Flexible and feature-complete Redis client for PHP and HHVM",
+            "homepage": "http://github.com/predis/predis",
+            "keywords": [
+                "nosql",
+                "predis",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/predis/predis/issues",
+                "source": "https://github.com/predis/predis/tree/v1.1.7"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/tillkruss",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-04T19:34:46+00:00"
+        },
         {
             "name": "psr/cache",
             "version": "2.0.0",
@@ -5344,9 +5410,9 @@
     "platform": {
         "php": ">=7.2.5",
         "ext-ctype": "*",
-        "ext-iconv": "*",
-        "ext-fileinfo": "*",
         "ext-dom": "*",
+        "ext-fileinfo": "*",
+        "ext-iconv": "*",
         "ext-libxml": "*"
     },
     "platform-dev": [],

--- a/config/packages/cache.yaml
+++ b/config/packages/cache.yaml
@@ -1,19 +1,16 @@
+parameters:
+    redis_url: '%env(string:REDIS_URL)%'
+
 framework:
     cache:
         # Unique name of your app: used to compute stable namespaces for cache keys.
         #prefix_seed: your_vendor_name/app_name
 
-        # The "app" cache stores to the filesystem by default.
-        # The data in this cache should persist between deploys.
-        # Other options include:
-
         # Redis
-        #app: cache.adapter.redis
-        #default_redis_provider: redis://localhost
-
-        # APCu (not recommended with heavy random-write workloads as memory fragmentation can cause perf issues)
-        #app: cache.adapter.apcu
+        app: cache.adapter.redis_tag_aware
 
         # Namespaced pools use the above "app" backend by default
-        #pools:
-            #my.dedicated.cache: null
+        pools:
+            cache.redis:
+                provider: provider.redis
+                tags: true

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -14,6 +14,7 @@ services:
         autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
         bind:
             $configSchema: '%config_schema%'
+            App\Cache\CacheInterface: '@App\Cache\Adapter\RedisCacheAdapter'
 
     # makes classes in src/ available to be used as services
     # this creates a service per class whose id is the fully-qualified class name
@@ -24,6 +25,12 @@ services:
             - '../src/Entity/'
             - '../src/Kernel.php'
             - '../src/Tests/'
+
+    provider.redis:
+        class: \Redis
+        factory: ['App\Cache\Provider\RedisCacheAdapterFactory', 'createConnection']
+        bind:
+            $redisUrl: '%redis_url%'
 
     App\Parser\FormatParser\XMLFormatParser:
         bind:
@@ -36,6 +43,7 @@ services:
         bind:
             $parsers:
                 - '@App\Parser\FormatParser\XMLFormatParser'
+
 
     # add more service definitions when explicit configuration is needed
     # please note that last definitions always *replace* previous ones

--- a/src/Cache/Adapter/RedisCacheAdapter.php
+++ b/src/Cache/Adapter/RedisCacheAdapter.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Cache\Adapter;
+
+use App\Cache\CacheInterface;
+use Psr\Cache\InvalidArgumentException;
+use Symfony\Contracts\Cache\ItemInterface;
+use Symfony\Contracts\Cache\TagAwareCacheInterface;
+use App\Cache\Collection\CacheableCollectionInterface;
+
+class RedisCacheAdapter implements CacheInterface
+{
+
+    public function __construct(private TagAwareCacheInterface $cache) {}
+
+    /**
+     * @inheritDoc
+     *
+     * @throws InvalidArgumentException
+     */
+    public function saveCollection(CacheableCollectionInterface $cacheableCollection): void
+    {
+        foreach ($cacheableCollection->getAll() as &$cacheableItem) {
+            $this->cache->get(
+                $cacheableItem->getCacheKey(),
+                function (ItemInterface $item) use (&$cacheableItem, &$cacheableCollection) {
+                    $item->tag($cacheableCollection->getTags());
+                    $item->expiresAfter($cacheableCollection->expiresAfter());
+
+                    return $cacheableItem->getCacheValue();
+                }
+            );
+        }
+    }
+}

--- a/src/Cache/CacheInterface.php
+++ b/src/Cache/CacheInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Cache;
+
+use App\Cache\Collection\CacheableCollectionInterface;
+
+interface CacheInterface
+{
+
+    /**
+     * Saves collection to cache by iteration over its items.
+     *
+     * @param CacheableCollectionInterface $cacheableCollection
+     */
+    public function saveCollection(CacheableCollectionInterface $cacheableCollection): void;
+}

--- a/src/Cache/Collection/CacheableCollection.php
+++ b/src/Cache/Collection/CacheableCollection.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace App\Cache\Collection;
+
+use DateInterval;
+use function in_array;
+use function array_values;
+
+class CacheableCollection implements CacheableCollectionInterface
+{
+
+    /** @var CacheableCollectionItemInterface[]  */
+    protected array $items;
+
+    /** @var string[] $tags */
+    protected array $tags;
+
+    /** @var DateInterval $expiresAfter */
+    protected DateInterval $expiresAfter;
+
+    /**
+     * @inheritDoc
+     */
+    public function add(CacheableCollectionItemInterface $item): self
+    {
+        $this->items[$item->getCacheKey()] = $item;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function get(string $key): ?CacheableCollectionItemInterface
+    {
+        return $this->items[$key] ?? null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getAll(): iterable
+    {
+        return array_values($this->items);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addTag(string $tag): self
+    {
+        if (!in_array($tag, $this->tags)) {
+            $this->tags[] = $tag;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setExpiresAfter(DateInterval|string $interval): self
+    {
+        if (!($interval instanceof DateInterval)) {
+            $interval = DateInterval::createFromDateString($interval);
+        }
+
+        $this->expiresAfter = $interval;
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAfter(): DateInterval
+    {
+        return $this->expiresAfter;
+    }
+}

--- a/src/Cache/Collection/CacheableCollectionInterface.php
+++ b/src/Cache/Collection/CacheableCollectionInterface.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Cache\Collection;
+
+use DateInterval;
+
+interface CacheableCollectionInterface
+{
+
+    /**
+     * Adds the item to the collection.
+     *
+     * @param CacheableCollectionItemInterface $item
+     * @return CacheableCollectionInterface
+     */
+    public function add(CacheableCollectionItemInterface $item): CacheableCollectionInterface;
+
+    /**
+     * Returns a single item based on provided key.
+     *
+     * @param string $key
+     * @return CacheableCollectionItemInterface|null
+     */
+    public function get(string $key): ?CacheableCollectionItemInterface;
+
+    /**
+     * Returns all items in collection.
+     *
+     * @return CacheableCollectionItemInterface[]
+     */
+    public function getAll(): iterable;
+
+    /**
+     * Adds tag for all items inside the collection.
+     *
+     * @param string $tag
+     * @return CacheableCollectionInterface
+     */
+    public function addTag(string $tag): CacheableCollectionInterface;
+
+    /**
+     * Returns tags used for all items inside the collection.
+     *
+     * @return array
+     */
+    public function getTags(): array;
+
+    /**
+     * Sets cache expiration for all items inside the collection.
+     *
+     * @param DateInterval|string $interval
+     * @return CacheableCollectionInterface
+     */
+    public function setExpiresAfter(DateInterval|string $interval): CacheableCollectionInterface;
+
+    /**
+     * Returns the expiration used for all items inside the collection.
+     *
+     * @return DateInterval
+     */
+    public function expiresAfter(): DateInterval;
+}

--- a/src/Cache/Collection/CacheableCollectionItem.php
+++ b/src/Cache/Collection/CacheableCollectionItem.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Cache\Collection;
+
+class CacheableCollectionItem implements CacheableCollectionItemInterface
+{
+
+    public function __construct(protected string $key, protected mixed $value) {}
+
+    /**
+     * @inheritDoc
+     */
+    public function getCacheKey(): string
+    {
+        return $this->key;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCacheValue(): mixed
+    {
+        return $this->value;
+    }
+}

--- a/src/Cache/Collection/CacheableCollectionItemInterface.php
+++ b/src/Cache/Collection/CacheableCollectionItemInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Cache\Collection;
+
+interface CacheableCollectionItemInterface
+{
+
+    /**
+     * Construct the instance of an item with mandatory fields.
+     *
+     * @param string $key
+     * @param string $value
+     */
+    public function __construct(string $key, string $value);
+
+    /**
+     * Returns the key under which item's value will be stored in cache.
+     *
+     * @return string
+     */
+    public function getCacheKey(): string;
+
+    /**
+     * Returns the value which will be stored in cache.
+     *
+     * @return mixed
+     */
+    public function getCacheValue(): mixed;
+}

--- a/src/Cache/Provider/RedisCacheAdapterFactory.php
+++ b/src/Cache/Provider/RedisCacheAdapterFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Cache\Provider;
+
+use Symfony\Component\Cache\Adapter\RedisAdapter;
+use Symfony\Component\Cache\Adapter\RedisTagAwareAdapter;
+use Symfony\Component\Cache\Adapter\TagAwareAdapterInterface;
+
+class RedisCacheAdapterFactory
+{
+
+    /**
+     * Creates tag-aware redis adapter.
+     *
+     * @param string $redisUrl
+     * @return TagAwareAdapterInterface
+     */
+    public static function createConnection(string $redisUrl): TagAwareAdapterInterface
+    {
+        $client = RedisAdapter::createConnection($redisUrl);
+        return new RedisTagAwareAdapter($client);
+    }
+}

--- a/src/Command/ConfigLoadCommand.php
+++ b/src/Command/ConfigLoadCommand.php
@@ -2,7 +2,7 @@
 
 namespace App\Command;
 
-use App\Service\ConfigLoaderService;
+use App\Service\ConfigService;
 use App\Exception\ConfigLoadException;
 use App\Enum\ConfigLoadCommandArgsEnum;
 use Symfony\Component\Console\Command\Command;
@@ -16,10 +16,7 @@ class ConfigLoadCommand extends Command
     protected static $defaultName = 'config:load';
     protected static $defaultDescription = 'Command used for parsing configuration files';
 
-    /**
-     * @param ConfigLoaderService $configLoaderService
-     */
-    public function __construct(private ConfigLoaderService $configLoaderService)
+    public function __construct(private ConfigService $configLoaderService)
     {
         parent::__construct();
     }

--- a/src/Dto/ConfigDto.php
+++ b/src/Dto/ConfigDto.php
@@ -2,36 +2,47 @@
 
 namespace App\Dto;
 
+use DateInterval;
+use App\Enum\CacheTagsEnum;
 use App\Parser\ConfigInterface;
+use App\Cache\Collection\CacheableCollection;
+use App\Cache\Collection\CacheableCollectionItemInterface;
 
-class ConfigDto implements ConfigInterface
+class ConfigDto extends CacheableCollection implements ConfigInterface
 {
-
-    /** @var array $configuration */
-    private array $configuration = [];
 
     /**
      * @inheritDoc
      */
     public function set(string $key, mixed $value): ConfigInterface
     {
-        $this->configuration[$key] = $value;
+        if ($value instanceof CacheableCollectionItemInterface) {
+            $this->add($value);
+        }
         return $this;
     }
 
     /**
      * @inheritDoc
      */
-    public function get(string $key): mixed
+    public function get(string $key): ?CacheableCollectionItemInterface
     {
-        return $this->configuration[$key] ?? null;
+        return $this->items[$key] ?? null;
     }
 
     /**
      * @inheritDoc
      */
-    public function exists(string $key): bool
+    public function getTags(): array
     {
-        return key_exists($key, $this->configuration);
+        return [ CacheTagsEnum::CONFIG ];
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function expiresAfter(): DateInterval
+    {
+        return DateInterval::createFromDateString('+3 hours');
     }
 }

--- a/src/Dto/CookieDto.php
+++ b/src/Dto/CookieDto.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Dto;
+
+use App\Cache\Collection\CacheableCollectionItem;
+
+class CookieDto extends CacheableCollectionItem
+{
+
+}

--- a/src/Dto/SubdomainsDto.php
+++ b/src/Dto/SubdomainsDto.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Dto;
+
+use App\Cache\Collection\CacheableCollectionItem;
+use function in_array;
+use function json_encode;
+
+class SubdomainsDto extends CacheableCollectionItem
+{
+
+    /**
+     * Adds provided subdomain to the subdomains array if it's not there already.
+     *
+     * @param string $subdomain
+     */
+    public function add(string $subdomain): void
+    {
+        if (!in_array($subdomain, $this->value)) {
+            $this->value[] = $subdomain;
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCacheValue(): string
+    {
+        $decoded = json_encode($this->value, JSON_UNESCAPED_SLASHES);
+        return $decoded === false ? '' : $decoded;
+    }
+}

--- a/src/Enum/CacheTagsEnum.php
+++ b/src/Enum/CacheTagsEnum.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace App\Enum;
+
+/**
+ * Native Enum types come with PHP v8.1 (still in beta), this is an alternative way to specify an enum type.
+ */
+class CacheTagsEnum
+{
+
+    public const CONFIG = 'config';
+}

--- a/src/Parser/ConfigInterface.php
+++ b/src/Parser/ConfigInterface.php
@@ -6,7 +6,7 @@ interface ConfigInterface
 {
 
     /**
-     * Sets provided $value to configuration object under provided $key
+     * Sets provided value to configuration object under provided key.
      *
      * @param string $key
      * @param mixed $value
@@ -14,20 +14,11 @@ interface ConfigInterface
      */
     public function set(string $key, mixed $value): ConfigInterface;
 
-
     /**
-     * Returns the configured value stored under provided key
+     * Returns the configured value stored under provided key.
      *
      * @param string $key
      * @return mixed
      */
     public function get(string $key): mixed;
-
-    /**
-     * Checks if the provided key exists in the configuration object
-     *
-     * @param string $key
-     * @return bool
-     */
-    public function exists(string $key): bool;
 }

--- a/src/Parser/ConfigParser.php
+++ b/src/Parser/ConfigParser.php
@@ -6,23 +6,15 @@ use App\Service\FileService;
 use App\Exception\FileException;
 use App\Exception\ParsingException;
 use App\Parser\FormatParser\FormatParserInterface;
+use function is_null;
 
 class ConfigParser implements ConfigParserInterface
 {
 
-    /**
-     * @param FormatParserInterface[] $parsers
-     * @param FileService $fileService
-     */
-    public function __construct(
-        private array $parsers,
-        private FileService $fileService,
-    ) {}
+    public function __construct(private array $parsers, private FileService $fileService) {}
 
     /**
-     * @param string $filepath
-     * @return ConfigInterface
-     * @throws ParsingException
+     * @inheritDoc
      */
     public function parseFile(string $filepath): ConfigInterface
     {
@@ -35,9 +27,7 @@ class ConfigParser implements ConfigParserInterface
     }
 
     /**
-     * @param string $content
-     * @return ConfigInterface
-     * @throws ParsingException
+     * @inheritDoc
      */
     public function parseString(string $content): ConfigInterface
     {

--- a/src/Parser/ConfigParserInterface.php
+++ b/src/Parser/ConfigParserInterface.php
@@ -2,22 +2,26 @@
 
 namespace App\Parser;
 
+use App\Exception\ParsingException;
+
 interface ConfigParserInterface
 {
 
     /**
-     * Reads file contents in specified $filepath, parses it and converts to ConfigInterface
+     * Reads file contents in specified filepath, parses it and converts to ConfigInterface.
      *
      * @param string $filepath
      * @return ConfigInterface
+     * @throws ParsingException
      */
     public function parseFile(string $filepath): ConfigInterface;
 
     /**
-     * Parses passed string and converts to ConfigInterface
+     * Parses passed string and converts to ConfigInterface.
      *
      * @param string $content
      * @return ConfigInterface
+     * @throws ParsingException
      */
     public function parseString(string $content): ConfigInterface;
 }

--- a/src/Parser/FormatParser/XMLFormatParser.php
+++ b/src/Parser/FormatParser/XMLFormatParser.php
@@ -34,9 +34,8 @@ class XMLFormatParser implements FormatParserInterface
         $config = new ConfigDto();
         $configNode = $dom->getElementsByTagName('config')->item(0);
         DOMUtils::iterateElements($configNode->childNodes, function ($node) use (&$config) {
-            $value = $this->parseNode($node);
-            if (!is_null($value)) {
-                $config->set($node->nodeName, $value);
+            foreach ($this->parseNode($node) as $parsed) {
+                $config->set($node->nodeName, $parsed);
             }
         });
 
@@ -72,15 +71,15 @@ class XMLFormatParser implements FormatParserInterface
      * Determines which Parser to use when parsing the node.
      *
      * @param DOMNode $node
-     * @return mixed
+     * @return array
      */
-    private function parseNode(DOMNode $node): mixed
+    private function parseNode(DOMNode $node): array
     {
         foreach ($this->nodeParsers as $nodeParser) {
             if ($nodeParser->supports($node)) {
                 return $nodeParser->parse($node);
             }
         }
-        return null;
+        return [];
     }
 }

--- a/src/Parser/XMLNodeParser/CookiesParser.php
+++ b/src/Parser/XMLNodeParser/CookiesParser.php
@@ -3,6 +3,7 @@
 namespace App\Parser\XMLNodeParser;
 
 use DOMNode;
+use App\Dto\CookieDto;
 use App\Utils\DOMUtils;
 use App\Enum\ConfigKeysEnum;
 
@@ -12,7 +13,7 @@ class CookiesParser implements XMLNodeParserInterface
     /**
      * @inheritDoc
      */
-    public function parse(DOMNode $node): array
+    public function parse(DOMNode $node): iterable
     {
         $cookies = [];
         DOMUtils::iterateElements($node->childNodes, function ($node) use (&$cookies) {
@@ -20,7 +21,7 @@ class CookiesParser implements XMLNodeParserInterface
             $name = $node->attributes->getNamedItem('name')->textContent;
             $host = $node->attributes->getNamedItem('host')->textContent;
             if (!empty($name) && !empty($host) && !empty($node->nodeValue)) {
-                $cookies["cookie:{$name}:{$host}"] = $node->nodeValue;
+                $cookies[] = new CookieDto("cookie:{$name}:{$host}", $node->nodeValue);
             }
         });
 

--- a/src/Parser/XMLNodeParser/SubdomainsParser.php
+++ b/src/Parser/XMLNodeParser/SubdomainsParser.php
@@ -4,6 +4,7 @@ namespace App\Parser\XMLNodeParser;
 
 use DOMNode;
 use App\Utils\DOMUtils;
+use App\Dto\SubdomainsDto;
 use App\Enum\ConfigKeysEnum;
 
 class SubdomainsParser implements XMLNodeParserInterface
@@ -12,17 +13,17 @@ class SubdomainsParser implements XMLNodeParserInterface
     /**
      * @inheritDoc
      */
-    public function parse(DOMNode $node): array
+    public function parse(DOMNode $node): iterable
     {
-        $subdomains = [];
+        $subdomains = new SubdomainsDto(ConfigKeysEnum::SUBDOMAINS, []);
         DOMUtils::iterateElements($node->childNodes, function ($node) use (&$subdomains) {
             /** @var DOMNode $node */
             if (!empty($node->nodeValue)) {
-                $subdomains[] = $node->nodeValue;
+                $subdomains->add($node->nodeValue);
             }
         });
 
-        return array_unique($subdomains);
+        return [ $subdomains ];
     }
 
     /**

--- a/src/Parser/XMLNodeParser/XMLNodeParserInterface.php
+++ b/src/Parser/XMLNodeParser/XMLNodeParserInterface.php
@@ -8,15 +8,15 @@ interface XMLNodeParserInterface
 {
 
     /**
-     * Extracts data from the provided node
+     * Extracts data from the provided node.
      *
      * @param DOMNode $node
      * @return mixed
      */
-    public function parse(DOMNode $node): mixed;
+    public function parse(DOMNode $node): iterable;
 
     /**
-     * Determines if the parser supports provided node
+     * Determines if the parser supports provided node.
      *
      * @param DOMNode $node
      * @return bool

--- a/src/Service/ConfigService.php
+++ b/src/Service/ConfigService.php
@@ -2,16 +2,20 @@
 
 namespace App\Service;
 
+use App\Dto\ConfigDto;
+use App\Cache\CacheInterface;
 use App\Exception\ParsingException;
 use App\Parser\ConfigParserInterface;
 use App\Exception\ConfigLoadException;
 
-class ConfigLoaderService
+class ConfigService
 {
 
-    public function __construct(private ConfigParserInterface $configParser) {}
+    public function __construct(private CacheInterface $cache, private ConfigParserInterface $configParser) {}
 
     /**
+     * Loads config from files and saves it to cache.
+     *
      * @param string $filepath
      * @throws ConfigLoadException
      */
@@ -19,8 +23,19 @@ class ConfigLoaderService
     {
         try {
             $config = $this->configParser->parseFile($filepath);
+            $this->save($config);
         } catch (ParsingException $e) {
             throw new ConfigLoadException(0, $e);
         }
+    }
+
+    /**
+     * Saves config to cache.
+     *
+     * @param ConfigDto $config
+     */
+    private function save(ConfigDto $config)
+    {
+        $this->cache->saveCollection($config);
     }
 }

--- a/src/Service/FileService.php
+++ b/src/Service/FileService.php
@@ -6,16 +6,13 @@ use App\Exception\FileException;
 use Symfony\Component\Filesystem\Filesystem;
 use function file_get_contents;
 
-/**
- * Service used for file content manipulation.
- */
 class FileService
 {
 
     public function __construct(private Filesystem $filesystem) {}
 
     /**
-     * Reads file content in the specified $filepath
+     * Reads file content in the specified filepath.
      *
      * @param string $filepath
      * @return string
@@ -36,7 +33,7 @@ class FileService
     }
 
     /**
-     * Reads the file and returns its contents
+     * Reads the file and returns its contents.
      *
      * @param string $filepath
      * @return string|bool

--- a/src/Utils/DOMUtils.php
+++ b/src/Utils/DOMUtils.php
@@ -36,7 +36,7 @@ class DOMUtils
     }
 
     /**
-     * Iterates the DOMNodeList and returns first element node or null
+     * Iterates the DOMNodeList and returns first element node or null.
      *
      * @param DOMNodeList $nodeList
      * @return DOMNode|null
@@ -78,7 +78,7 @@ class DOMUtils
     }
 
     /**
-     * Counts all the element nodes in DOMNodeList
+     * Counts all the element nodes in DOMNodeList.
      *
      * @param DOMNodeList $nodeList
      * @return int
@@ -93,10 +93,10 @@ class DOMUtils
     }
 
     /**
-     * Determines the node type
+     * Determines the node type base on its arguments, value and/or provided expected type.
      *
      * @param DOMNode $node
-     * @param string|null $expectedType <- used for arrays, as they may have no elements
+     * @param string|null $expectedType
      * @return string
      */
     public static function determineNodeType(DOMNode $node, ?string $expectedType = null): string

--- a/src/Validator/ConfigValidatorInterface.php
+++ b/src/Validator/ConfigValidatorInterface.php
@@ -6,7 +6,7 @@ interface ConfigValidatorInterface
 {
 
     /**
-     * Validates passed content
+     * Validates passed content.
      *
      * @param mixed $content
      * @return bool

--- a/src/Validator/XMLConfigValidator.php
+++ b/src/Validator/XMLConfigValidator.php
@@ -7,7 +7,7 @@ use DOMDocument;
 use App\Utils\DOMUtils;
 
 /**
- * Validates XML Config file
+ * Validates XML Config file.
  */
 class XMLConfigValidator extends AbstractConfigValidator
 {

--- a/symfony.lock
+++ b/symfony.lock
@@ -55,6 +55,9 @@
             "tests/bootstrap.php"
         ]
     },
+    "predis/predis": {
+        "version": "v1.1.7"
+    },
     "psr/cache": {
         "version": "1.0.1"
     },

--- a/tests/Unit/Command/ConfigLoadCommandTest.php
+++ b/tests/Unit/Command/ConfigLoadCommandTest.php
@@ -3,7 +3,7 @@
 namespace App\Tests\Unit\Command;
 
 use App\Command\ConfigLoadCommand;
-use App\Service\ConfigLoaderService;
+use App\Service\ConfigService;
 use App\Exception\ConfigLoadException;
 use App\Enum\ConfigLoadCommandArgsEnum;
 use Symfony\Component\Console\Command\Command;
@@ -36,7 +36,7 @@ class ConfigLoadCommandTest extends KernelTestCase
 
     public function testArgumentFilepathShouldBeRequired(): void
     {
-        $configLoaderServiceMock = $this->getMockBuilder(ConfigLoaderService::class)
+        $configLoaderServiceMock = $this->getMockBuilder(ConfigService::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -49,7 +49,7 @@ class ConfigLoadCommandTest extends KernelTestCase
 
     public function testShouldExecuteCorrectlyWithRequiredArgument(): void
     {
-        $configLoaderServiceMock = $this->getMockBuilder(ConfigLoaderService::class)
+        $configLoaderServiceMock = $this->getMockBuilder(ConfigService::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -63,7 +63,7 @@ class ConfigLoadCommandTest extends KernelTestCase
 
     public function testShouldCallLoadFromFileWithCorrectArguments(): void
     {
-        $configLoaderServiceMock = $this->getMockBuilder(ConfigLoaderService::class)
+        $configLoaderServiceMock = $this->getMockBuilder(ConfigService::class)
             ->disableOriginalConstructor()
             ->getMock();
 
@@ -80,7 +80,7 @@ class ConfigLoadCommandTest extends KernelTestCase
 
     public function testShouldDisplayErrorMessageOnFailure(): void
     {
-        $configLoaderServiceMock = $this->getMockBuilder(ConfigLoaderService::class)
+        $configLoaderServiceMock = $this->getMockBuilder(ConfigService::class)
             ->disableOriginalConstructor()
             ->getMock();
 


### PR DESCRIPTION
New:
 - added cache dependencies with corresponding env variables
 - created cache saving under tags
 - created custom cache collections with possibility to save collection to cache all at once
 - created Dtos for parsed content

Update:
 - improved `ConfigDto` which now use cache collections
 - improved and unified annotations
 - changed the way `XMLNodeParsers` work